### PR TITLE
designated flags and added description to command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+My version of grep includes only 5 flags and works only with .txt files so it's really incomplete. 
+But i really learned a lot while writing this mini project, and i think it still is a very userfull tool.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,5 @@
 /*
 Copyright © 2024 NAME HERE <EMAIL ADDRESS>
-
 */
 package cmd
 
@@ -10,42 +9,29 @@ import (
 	"github.com/spf13/cobra"
 )
 
-
-
 // rootCmd represents the base command when called without any subcommands
-var rootCmd = &cobra.Command{
-	Use:   "myGrep",
-	Short: "A brief description of your application",
-	Long: `A longer description that spans multiple lines and likely contains
-examples and usage of using your application. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
-	// Uncomment the following line if your bare application
-	// has an action associated with it:
-	// Run: func(cmd *cobra.Command, args []string) { },
+var grepCmd = &cobra.Command{
+	Use:   "grep",
+	Short: "My version of grep",
+	Long:  "command-line utility for searching plain-text data sets for lines that match a regular expression.\ng/re/p (global / regular expression search / and print)",
+	Run:   grep,
 }
 
-// Execute adds all child commands to the root command and sets flags appropriately.
-// This is called by main.main(). It only needs to happen once to the rootCmd.
+func init() {
+	grepCmd.Flags().BoolP("ignore-case", "i", false, "Ignores case distinctions in patterns and input data")
+	grepCmd.Flags().BoolP("invert-match", "v", false, "Selects the non-matching lines of the provided input pattern")
+	grepCmd.Flags().BoolP("line-number", "n", false, "Prefix each line of the matching output with the line number in the input file")
+	grepCmd.Flags().BoolP("word-regexp", "w", false, "Find the exact matching word from the input file or string")
+	grepCmd.Flags().BoolP("count", "c", false, "Count the number of occurrences of the provided pattern instead of outputing the lines")
+}
+
+func grep(cmd *cobra.Command, args []string) {
+
+}
+
 func Execute() {
-	err := rootCmd.Execute()
+	err := grepCmd.Execute()
 	if err != nil {
 		os.Exit(1)
 	}
 }
-
-func init() {
-	// Here you will define your flags and configuration settings.
-	// Cobra supports persistent flags, which, if defined here,
-	// will be global for your application.
-
-	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.myGrep.yaml)")
-
-	// Cobra also supports local flags, which will only run
-	// when this action is called directly.
-	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-}
-
-


### PR DESCRIPTION
flags: 
--ignore-case -i  - Ignores case distinctions in patterns and input data
--invert-match -v - Selects the non-matching lines of the provided input pattern
--line-number - n - Prefixes each line of the matching output with the line number in the input file
--word-regexp -w - Find the exact matching word from the input file or string
--count -c - Count the number of lines on which occurences happened of the provided pattern instead of outputing the lines